### PR TITLE
#248 Hotfixes - 테스트 yml 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ logs/
 
 application.properties
 application.yml
+application-test.properties
+application-test.yml
 
 ### STS ###
 .apt_generated

--- a/src/test/java/com/gabia/gyebalja/board/BoardControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/board/BoardControllerTest.java
@@ -45,7 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class BoardControllerTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/board/BoardRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/board/BoardRepositoryTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -30,8 +31,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
+@ActiveProfiles("test")
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class BoardRepositoryTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/board/BoardServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/board/BoardServiceTest.java
@@ -29,6 +29,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
@@ -43,8 +44,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
+@ActiveProfiles("test")
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class BoardServiceTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/boardImg/BoardImgRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/boardImg/BoardImgRepositoryTest.java
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class BoardImgRepositoryTest {
     @PersistenceContext
     EntityManager em;

--- a/src/test/java/com/gabia/gyebalja/category/CategoryControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/category/CategoryControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -31,7 +32,8 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class CategoryControllerTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/category/CategoryRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/category/CategoryRepositoryTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class CategoryRepositoryTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/category/CategoryServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/category/CategoryServiceTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class CategoryServiceTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/comment/CommentControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/comment/CommentControllerTest.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class CommentControllerTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/comment/CommentRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/comment/CommentRepositoryTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class CommentRepositoryTest {
 
     @Autowired private CommentRepository commentRepository;

--- a/src/test/java/com/gabia/gyebalja/comment/CommentServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/comment/CommentServiceTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class CommentServiceTest {
 
     @Autowired private CommentRepository commentRepository;

--- a/src/test/java/com/gabia/gyebalja/common/HashTagRegularExpressionTest.java
+++ b/src/test/java/com/gabia/gyebalja/common/HashTagRegularExpressionTest.java
@@ -2,7 +2,6 @@ package com.gabia.gyebalja.common;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class HashTagRegularExpressionTest {
     
     @Test

--- a/src/test/java/com/gabia/gyebalja/department/DepartmentControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/department/DepartmentControllerTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class DepartmentControllerTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/department/DepartmentRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/department/DepartmentRepositoryTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class DepartmentRepositoryTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/department/DepartmentServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/department/DepartmentServiceTest.java
@@ -23,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class DepartmentServiceTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationControllerTest.java
@@ -42,7 +42,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class EducationControllerTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/education/EducationRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationRepositoryTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 class EducationRepositoryTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/education/EducationServiceTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class EducationServiceTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/edutag/EduTagRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/edutag/EduTagRepositoryTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class EduTagRepositoryTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/likes/LikesControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/likes/LikesControllerTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class LikesControllerTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/likes/LikesRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/likes/LikesRepositoryTest.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 class LikesRepositoryTest {
 
     @Autowired private LikesRepository likesRepository;

--- a/src/test/java/com/gabia/gyebalja/likes/LikesServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/likes/LikesServiceTest.java
@@ -37,7 +37,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class LikesServiceTest {
 
     @Autowired private BoardRepository boardRepository;

--- a/src/test/java/com/gabia/gyebalja/statistics/StatisticsControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/statistics/StatisticsControllerTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class StatisticsControllerTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/statistics/StatisticsServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/statistics/StatisticsServiceTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class StatisticsServiceTest {
 
     @Autowired private DepartmentRepository departmentRepository;

--- a/src/test/java/com/gabia/gyebalja/tag/TagControllerTest.java
+++ b/src/test/java/com/gabia/gyebalja/tag/TagControllerTest.java
@@ -31,7 +31,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
  * Part : All
  */
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT, properties = "spring.config.location=classpath:application-test.yml")
 public class TagControllerTest {
 
     @Autowired

--- a/src/test/java/com/gabia/gyebalja/tag/TagRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/tag/TagRepositoryTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@DataJpaTest
+@DataJpaTest(properties = "spring.config.location=classpath:application-test.yml")
 public class TagRepositoryTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/tag/TagServiceTest.java
+++ b/src/test/java/com/gabia/gyebalja/tag/TagServiceTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class TagServiceTest {
 
     @PersistenceContext

--- a/src/test/java/com/gabia/gyebalja/user/UserRepositoryTest.java
+++ b/src/test/java/com/gabia/gyebalja/user/UserRepositoryTest.java
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 
 @Transactional
-@SpringBootTest
+@SpringBootTest(properties = "spring.config.location=classpath:application-test.yml")
 public class UserRepositoryTest {
 
     @PersistenceContext


### PR DESCRIPTION
#248 Hotfixes - 테스트 yml 설정

- 테스트 시에 테스트 전용 데이터베이스 사용하기 위해 yml 파일 교체

> [branch 명]
> hotfix/#246-fixTestDb 오타입니다. (원래 hotfix/#248-fixTestDb가 맞습니다.)